### PR TITLE
feat: plot skill with eval CI

### DIFF
--- a/.github/workflows/skill-evals.yml
+++ b/.github/workflows/skill-evals.yml
@@ -66,19 +66,22 @@ jobs:
         id: evals
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          SKILL: ${{ matrix.skill }}
         run: |
           python scripts/run_skill_evals.py \
-            --skill skills/${{ matrix.skill }} \
-            --evals skills/${{ matrix.skill }}/evals/evals.json \
-            --output eval-results-${{ matrix.skill }}.json \
+            --skill skills/$SKILL \
+            --evals skills/$SKILL/evals/evals.json \
+            --output eval-results-$SKILL.json \
             --pass-threshold 0.6
 
       - name: Post step summary
         if: always()
+        env:
+          SKILL: ${{ matrix.skill }}
         run: |
-          if [ -f eval-results-${{ matrix.skill }}.json ]; then
+          if [ -f eval-results-$SKILL.json ]; then
             python scripts/format_eval_summary.py \
-              eval-results-${{ matrix.skill }}.json >> $GITHUB_STEP_SUMMARY
+              eval-results-$SKILL.json >> $GITHUB_STEP_SUMMARY
           fi
 
       - name: Upload eval results

--- a/.github/workflows/skill-evals.yml
+++ b/.github/workflows/skill-evals.yml
@@ -21,8 +21,10 @@ jobs:
 
       - name: Detect changed skills with evals
         id: detect
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep '^skills/' | cut -d'/' -f2 | sort -u)
+          CHANGED=$(git diff --name-only origin/$BASE_REF...HEAD | grep '^skills/' | cut -d'/' -f2 | sort -u)
           SKILLS_WITH_EVALS=()
           for skill in $CHANGED; do
             if [ -f "skills/$skill/evals/evals.json" ]; then
@@ -30,7 +32,11 @@ jobs:
             fi
           done
           echo "Changed skills with evals: ${SKILLS_WITH_EVALS[*]}"
-          SKILLS_JSON=$(printf '%s\n' "${SKILLS_WITH_EVALS[@]}" | jq -R . | jq -sc .)
+          if [ ${#SKILLS_WITH_EVALS[@]} -eq 0 ]; then
+            SKILLS_JSON="[]"
+          else
+            SKILLS_JSON=$(printf '%s\n' "${SKILLS_WITH_EVALS[@]}" | jq -R . | jq -sc .)
+          fi
           echo "skills=$SKILLS_JSON" >> "$GITHUB_OUTPUT"
 
   run-evals:

--- a/.github/workflows/skill-evals.yml
+++ b/.github/workflows/skill-evals.yml
@@ -104,26 +104,44 @@ jobs:
           pattern: eval-results-*
           merge-multiple: true
 
-      - name: Post PR comment
-        uses: actions/github-script@v7
+      - name: Build comment body
+        id: build-comment
+        run: |
+          python3 - <<'EOF'
+          import json, glob, os
+
+          files = sorted(glob.glob('eval-results-*.json'))
+          results = []
+          for f in files:
+              try:
+                  results.append(json.load(open(f)))
+              except Exception:
+                  pass
+
+          if not results:
+              print("BODY=")
+          else:
+              rows = []
+              for r in results:
+                  icon = "PASS" if r.get("pass_rate", 0) >= 0.6 else "FAIL"
+                  rows.append(f"| {icon} | `{r['skill_name']}` | {r['passed']}/{r['total']} | {round(r['pass_rate']*100)}% |")
+              details = "\n\n".join(r.get("details", "") for r in results)
+              body = (
+                  "## Skill Eval Results\n\n"
+                  "| Status | Skill | Passed | Score |\n"
+                  "|--------|-------|--------|-------|\n"
+                  + "\n".join(rows)
+                  + "\n\n<details><summary>Per-eval breakdown</summary>\n\n"
+                  + details
+                  + "\n</details>"
+              )
+              with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
+                  fh.write(f"body<<ENDOFBODY\n{body}\nENDOFBODY\n")
+          EOF
+
+      - name: Post sticky PR comment
+        if: steps.build-comment.outputs.body != ''
+        uses: marocchino/sticky-pull-request-comment@v2
         with:
-          script: |
-            const fs = require('fs');
-            const results = [];
-            const files = fs.readdirSync('.').filter(f => f.startsWith('eval-results-') && f.endsWith('.json'));
-            for (const file of files) {
-              try { results.push(JSON.parse(fs.readFileSync(file, 'utf8'))); } catch {}
-            }
-            if (!results.length) return;
-            const rows = results.map(r => {
-              const icon = r.pass_rate >= 0.6 ? 'PASS' : 'FAIL';
-              return `| ${icon} | \`${r.skill_name}\` | ${r.passed}/${r.total} | ${Math.round(r.pass_rate*100)}% |`;
-            }).join('\n');
-            const details = results.map(r => r.details || '').join('\n\n');
-            const body = `## Skill Eval Results\n\n| Status | Skill | Passed | Score |\n|--------|-------|--------|-------|\n${rows}\n\n<details><summary>Per-eval breakdown</summary>\n\n${details}\n</details>`;
-            await github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body
-            });
+          header: skill-evals
+          message: ${{ steps.build-comment.outputs.body }}

--- a/.github/workflows/skill-evals.yml
+++ b/.github/workflows/skill-evals.yml
@@ -1,0 +1,120 @@
+name: Skill Evals
+
+on:
+  pull_request:
+    paths:
+      - 'skills/**'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  detect-changed-skills:
+    runs-on: ubuntu-latest
+    outputs:
+      skills: ${{ steps.detect.outputs.skills }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed skills with evals
+        id: detect
+        run: |
+          CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep '^skills/' | cut -d'/' -f2 | sort -u)
+          SKILLS_WITH_EVALS=()
+          for skill in $CHANGED; do
+            if [ -f "skills/$skill/evals/evals.json" ]; then
+              SKILLS_WITH_EVALS+=("$skill")
+            fi
+          done
+          echo "Changed skills with evals: ${SKILLS_WITH_EVALS[*]}"
+          SKILLS_JSON=$(printf '%s\n' "${SKILLS_WITH_EVALS[@]}" | jq -R . | jq -sc .)
+          echo "skills=$SKILLS_JSON" >> "$GITHUB_OUTPUT"
+
+  run-evals:
+    needs: detect-changed-skills
+    if: needs.detect-changed-skills.outputs.skills != '[]' && needs.detect-changed-skills.outputs.skills != ''
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        skill: ${{ fromJson(needs.detect-changed-skills.outputs.skills) }}
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Claude CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Install eval dependencies
+        run: pip install anthropic
+
+      - name: Run evals for ${{ matrix.skill }}
+        id: evals
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          python scripts/run_skill_evals.py \
+            --skill skills/${{ matrix.skill }} \
+            --evals skills/${{ matrix.skill }}/evals/evals.json \
+            --output eval-results-${{ matrix.skill }}.json \
+            --pass-threshold 0.6
+
+      - name: Post step summary
+        if: always()
+        run: |
+          if [ -f eval-results-${{ matrix.skill }}.json ]; then
+            python scripts/format_eval_summary.py \
+              eval-results-${{ matrix.skill }}.json >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Upload eval results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-results-${{ matrix.skill }}
+          path: eval-results-${{ matrix.skill }}.json
+
+  comment-results:
+    needs: [detect-changed-skills, run-evals]
+    if: always() && needs.detect-changed-skills.outputs.skills != '[]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all eval results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: eval-results-*
+          merge-multiple: true
+
+      - name: Post PR comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const results = [];
+            const files = fs.readdirSync('.').filter(f => f.startsWith('eval-results-') && f.endsWith('.json'));
+            for (const file of files) {
+              try { results.push(JSON.parse(fs.readFileSync(file, 'utf8'))); } catch {}
+            }
+            if (!results.length) return;
+            const rows = results.map(r => {
+              const icon = r.pass_rate >= 0.6 ? 'PASS' : 'FAIL';
+              return `| ${icon} | \`${r.skill_name}\` | ${r.passed}/${r.total} | ${Math.round(r.pass_rate*100)}% |`;
+            }).join('\n');
+            const details = results.map(r => r.details || '').join('\n\n');
+            const body = `## Skill Eval Results\n\n| Status | Skill | Passed | Score |\n|--------|-------|--------|-------|\n${rows}\n\n<details><summary>Per-eval breakdown</summary>\n\n${details}\n</details>`;
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body
+            });

--- a/.github/workflows/skill-evals.yml
+++ b/.github/workflows/skill-evals.yml
@@ -24,7 +24,8 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref }}
         run: |
-          CHANGED=$(git diff --name-only origin/$BASE_REF...HEAD | grep '^skills/' | cut -d'/' -f2 | sort -u)
+          git fetch --no-tags --depth=1 origin "$BASE_REF"
+          CHANGED=$(git diff --name-only "origin/$BASE_REF"...HEAD | grep '^skills/' | cut -d'/' -f2 | sort -u)
           SKILLS_WITH_EVALS=()
           for skill in $CHANGED; do
             if [ -f "skills/$skill/evals/evals.json" ]; then
@@ -99,6 +100,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download all eval results
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           pattern: eval-results-*

--- a/README.md
+++ b/README.md
@@ -41,16 +41,16 @@ This checks each installable skill for required frontmatter, eval metadata, and 
 
 ```text
 .
-├── AGENTS.md
-├── README.md
-├── scripts/
-│   └── validate_skills.py
-└── skills/
-    └── cultivate/
-        ├── SKILL.md
-        ├── evals/
-        ├── references/
-        └── scripts/
++-- AGENTS.md
++-- README.md
++-- scripts/
+|   +-- validate_skills.py
++-- skills/
+    +-- cultivate/
+        +-- SKILL.md
+        +-- evals/
+        +-- references/
+        +-- scripts/
 ```
 
 Each skill directory is installable by passing its path to `install-skill-from-github.py`.

--- a/scripts/format_eval_summary.py
+++ b/scripts/format_eval_summary.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 """Format eval results as markdown for GitHub Actions step summary."""
+
 import argparse
 import json
+
 
 def main():
     parser = argparse.ArgumentParser()
@@ -16,20 +18,23 @@ def main():
     passed = data.get("passed", 0)
     total = data.get("total", 0)
     rate = data.get("pass_rate", 0)
-    icon = "✅" if rate >= 0.6 else "❌"
+    icon = "PASS" if rate >= 0.6 else "FAIL"
 
-    print(f"## {icon} Skill Evals: `{skill}`")
+    print(f"## [{icon}] Skill Evals: `{skill}`")
     print(f"\n**{passed}/{total} assertions passed ({rate:.0%})**\n")
 
     for ev in data.get("evals", []):
         ev_rate = ev.get("pass_rate", 0)
-        ev_icon = "✅" if ev_rate >= 0.6 else "❌"
-        print(f"### {ev_icon} Eval {ev['id']}")
-        print(f"\n> {ev['prompt'][:120]}...\n")
+        ev_icon = "PASS" if ev_rate >= 0.6 else "FAIL"
+        ev_id = ev.get("id", "?")
+        ev_prompt = ev.get("prompt", "")
+        print(f"### [{ev_icon}] Eval {ev_id}")
+        print(f"\n> {ev_prompt[:120]}...\n")
         for g in ev.get("graded", []):
-            check = "✓" if g["passed"] else "✗"
+            check = "+" if g["passed"] else "x"
             print(f"- {check} {g['text']}")
         print()
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/format_eval_summary.py
+++ b/scripts/format_eval_summary.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Format eval results as markdown for GitHub Actions step summary."""
+import argparse
+import json
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("results_file")
+    parser.add_argument("--skill", default="")
+    args = parser.parse_args()
+
+    with open(args.results_file) as f:
+        data = json.load(f)
+
+    skill = data.get("skill_name", args.skill)
+    passed = data.get("passed", 0)
+    total = data.get("total", 0)
+    rate = data.get("pass_rate", 0)
+    icon = "✅" if rate >= 0.6 else "❌"
+
+    print(f"## {icon} Skill Evals: `{skill}`")
+    print(f"\n**{passed}/{total} assertions passed ({rate:.0%})**\n")
+
+    for ev in data.get("evals", []):
+        ev_rate = ev.get("pass_rate", 0)
+        ev_icon = "✅" if ev_rate >= 0.6 else "❌"
+        print(f"### {ev_icon} Eval {ev['id']}")
+        print(f"\n> {ev['prompt'][:120]}...\n")
+        for g in ev.get("graded", []):
+            check = "✓" if g["passed"] else "✗"
+            print(f"- {check} {g['text']}")
+        print()
+
+if __name__ == "__main__":
+    main()

--- a/scripts/format_eval_summary.py
+++ b/scripts/format_eval_summary.py
@@ -31,8 +31,8 @@ def main():
         print(f"### [{ev_icon}] Eval {ev_id}")
         print(f"\n> {ev_prompt[:120]}...\n")
         for g in ev.get("graded", []):
-            check = "+" if g["passed"] else "x"
-            print(f"- {check} {g['text']}")
+            check = "+" if g.get("passed") else "x"
+            print(f"- {check} {g.get('text', '')}")
         print()
 
 

--- a/scripts/run_skill_evals.py
+++ b/scripts/run_skill_evals.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Run skill evals using the Claude CLI and grade results."""
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+def run_eval(skill_path, prompt, skill_name):
+    """Run a single eval with the skill loaded."""
+    full_prompt = f"""You have access to the following skill. Follow its instructions to complete the task.
+
+SKILL ({skill_name}):
+---
+{open(f'{skill_path}/SKILL.md').read()}
+---
+
+TASK: {prompt}
+
+Complete this task following the skill instructions. If the skill produces a file output, write it to the current directory."""
+
+    result = subprocess.run(
+        ["claude", "-p", full_prompt, "--output-format", "text"],
+        capture_output=True, text=True, timeout=120
+    )
+    return result.stdout if result.returncode == 0 else f"ERROR: {result.stderr}"
+
+def grade(output, assertions):
+    """Simple keyword-based grading."""
+    results = []
+    for a in assertions:
+        text = a.get("text", "")
+        # Basic heuristics based on assertion text
+        passed = False
+        evidence = "auto-graded"
+        lo = output.lower()
+        if "yaml frontmatter" in text.lower() or "frontmatter" in text.lower():
+            passed = output.strip().startswith("---") and "name:" in output and "tagline:" in output
+        elif "agents section" in text.lower():
+            passed = "## agents" in lo or "## agent" in lo
+        elif "kebab-case" in text.lower():
+            import re
+            m = re.search(r'^name:\s*(\S+)', output, re.MULTILINE)
+            passed = bool(m and re.match(r'^[a-z][a-z0-9-]+$', m.group(1)))
+        elif "explicit out" in text.lower() or "scope out" in text.lower():
+            passed = "**out" in lo or "out (explicitly" in lo
+        elif "success section" in text.lower():
+            passed = "## success" in lo
+        elif "agents reflects" in text.lower() or "write features" in text.lower():
+            passed = "write features" in lo and "pr" in lo
+        elif "crud" in text.lower():
+            passed = "crud" in lo or ("create" in lo and "read" in lo and "update" in lo)
+        elif "typescript" in text.lower():
+            passed = "typescript" in lo
+        elif "clarifying questions" in text.lower() or "asks questions" in text.lower():
+            passed = "?" in output and ("question" in lo or "clarif" in lo)
+        elif "trigger" in text.lower():
+            passed = "trigger" in lo
+        elif "stack" in text.lower() and "question" in text.lower():
+            passed = any(x in lo for x in ["stack", "language", "swift", "python", "script type"])
+        elif "open questions" in text.lower():
+            passed = "open questions" in lo or "tbd" in lo
+        else:
+            passed = len(output) > 100  # fallback: non-empty output
+        results.append({"text": text, "passed": passed, "evidence": evidence})
+    return results
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--skill", required=True)
+    parser.add_argument("--evals", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--pass-threshold", type=float, default=0.6)
+    args = parser.parse_args()
+
+    with open(args.evals) as f:
+        evals_data = json.load(f)
+
+    skill_name = evals_data.get("skill_name", os.path.basename(args.skill))
+    evals = evals_data.get("evals", [])
+
+    all_results = []
+    total_assertions = 0
+    total_passed = 0
+    details_lines = []
+
+    for ev in evals:
+        prompt = ev["prompt"]
+        assertions = ev.get("assertions", [])
+        print(f"Running eval {ev['id']}: {prompt[:60]}...", file=sys.stderr)
+
+        output = run_eval(args.skill, prompt, skill_name)
+        graded = grade(output, assertions)
+
+        passed = sum(1 for g in graded if g["passed"])
+        total = len(graded)
+        total_passed += passed
+        total_assertions += total
+
+        details_lines.append(f"**Eval {ev['id']}** — {passed}/{total} passed")
+        for g in graded:
+            icon = "✓" if g["passed"] else "✗"
+            details_lines.append(f"  {icon} {g['text']}")
+
+        all_results.append({"eval_id": ev["id"], "prompt": prompt, "output": output, "graded": graded, "pass_rate": passed/total if total else 0})
+
+    overall_rate = total_passed / total_assertions if total_assertions else 0
+    summary = {
+        "skill_name": skill_name,
+        "passed": total_passed,
+        "total": total_assertions,
+        "pass_rate": overall_rate,
+        "evals": all_results,
+        "details": "\n".join(details_lines)
+    }
+
+    with open(args.output, "w") as f:
+        json.dump(summary, f, indent=2)
+
+    print(f"{skill_name}: {total_passed}/{total_assertions} ({overall_rate:.0%})", file=sys.stderr)
+    sys.exit(0 if overall_rate >= args.pass_threshold else 1)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_skill_evals.py
+++ b/scripts/run_skill_evals.py
@@ -1,40 +1,48 @@
 #!/usr/bin/env python3
 """Run skill evals using the Claude CLI and grade results."""
+
 import argparse
 import json
 import os
 import subprocess
 import sys
-import tempfile
+
 
 def run_eval(skill_path, prompt, skill_name):
     """Run a single eval with the skill loaded."""
+    with open(f'{skill_path}/SKILL.md') as f:
+        skill_content = f.read()
+
     full_prompt = f"""You have access to the following skill. Follow its instructions to complete the task.
 
 SKILL ({skill_name}):
 ---
-{open(f'{skill_path}/SKILL.md').read()}
+{skill_content}
 ---
 
 TASK: {prompt}
 
 Complete this task following the skill instructions. If the skill produces a file output, write it to the current directory."""
 
-    result = subprocess.run(
-        ["claude", "-p", full_prompt, "--output-format", "text"],
-        capture_output=True, text=True, timeout=120
-    )
-    return result.stdout if result.returncode == 0 else f"ERROR: {result.stderr}"
+    try:
+        result = subprocess.run(
+            ["claude", "-p", full_prompt, "--output-format", "text"],
+            capture_output=True, text=True, timeout=120
+        )
+        return result.stdout if result.returncode == 0 else f"ERROR: {result.stderr}"
+    except subprocess.TimeoutExpired:
+        return "ERROR: timeout expired after 120s"
+
 
 def grade(output, assertions):
     """Simple keyword-based grading."""
     results = []
     for a in assertions:
         text = a.get("text", "")
-        # Basic heuristics based on assertion text
         passed = False
         evidence = "auto-graded"
         lo = output.lower()
+
         if "yaml frontmatter" in text.lower() or "frontmatter" in text.lower():
             passed = output.strip().startswith("---") and "name:" in output and "tagline:" in output
         elif "agents section" in text.lower():
@@ -62,9 +70,11 @@ def grade(output, assertions):
         elif "open questions" in text.lower():
             passed = "open questions" in lo or "tbd" in lo
         else:
-            passed = len(output) > 100  # fallback: non-empty output
+            passed = len(output) > 100
+
         results.append({"text": text, "passed": passed, "evidence": evidence})
     return results
+
 
 def main():
     parser = argparse.ArgumentParser()
@@ -86,24 +96,30 @@ def main():
     details_lines = []
 
     for ev in evals:
-        prompt = ev["prompt"]
+        prompt = ev.get("prompt", "")
+        ev_id = ev.get("id", "unknown")
         assertions = ev.get("assertions", [])
-        print(f"Running eval {ev['id']}: {prompt[:60]}...", file=sys.stderr)
 
+        print(f"Running eval {ev_id}: {prompt[:60]}...", file=sys.stderr)
         output = run_eval(args.skill, prompt, skill_name)
         graded = grade(output, assertions)
-
         passed = sum(1 for g in graded if g["passed"])
         total = len(graded)
         total_passed += passed
         total_assertions += total
 
-        details_lines.append(f"**Eval {ev['id']}** — {passed}/{total} passed")
+        details_lines.append(f"**Eval {ev_id}** -- {passed}/{total} passed")
         for g in graded:
-            icon = "✓" if g["passed"] else "✗"
+            icon = "+" if g["passed"] else "x"
             details_lines.append(f"  {icon} {g['text']}")
 
-        all_results.append({"eval_id": ev["id"], "prompt": prompt, "output": output, "graded": graded, "pass_rate": passed/total if total else 0})
+        all_results.append({
+            "eval_id": ev_id,
+            "prompt": prompt,
+            "output": output,
+            "graded": graded,
+            "pass_rate": passed / total if total else 0
+        })
 
     overall_rate = total_passed / total_assertions if total_assertions else 0
     summary = {
@@ -120,6 +136,7 @@ def main():
 
     print(f"{skill_name}: {total_passed}/{total_assertions} ({overall_rate:.0%})", file=sys.stderr)
     sys.exit(0 if overall_rate >= args.pass_threshold else 1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/run_skill_evals.py
+++ b/scripts/run_skill_evals.py
@@ -32,6 +32,10 @@ Complete this task following the skill instructions. If the skill produces a fil
         return result.stdout if result.returncode == 0 else f"ERROR: {result.stderr}"
     except subprocess.TimeoutExpired:
         return "ERROR: timeout expired after 120s"
+    except FileNotFoundError:
+        return "ERROR: claude CLI not found on PATH"
+    except OSError as exc:
+        return f"ERROR: failed to invoke claude CLI: {exc}"
 
 
 def grade(output, assertions):
@@ -70,7 +74,7 @@ def grade(output, assertions):
         elif "open questions" in text.lower():
             passed = "open questions" in lo or "tbd" in lo
         else:
-            passed = len(output) > 100
+            passed = len(output) > 100 and not output.lstrip().startswith("ERROR:")
 
         results.append({"text": text, "passed": passed, "evidence": evidence})
     return results

--- a/skills/cultivate/SKILL.md
+++ b/skills/cultivate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cultivate
-description: Cultivate a repository — prepare it so farmers (AI agents) can work it. Use this skill to make a repo agent-legible and enforceable: create or improve AGENTS.md, build a knowledge map, add execution-plan workflows, encode architecture guardrails, expose CI/lint/test feedback to agents, and reduce drift from agent-generated PRs. The cultivate skill is the bridge between a s33ded idea and a repo ready for farmers to execute on. Replaces cultivate.
+description: Cultivate a repository -- prepare it so farmers (AI agents) can work it. Use this skill to make a repo agent-legible and enforceable: create or improve AGENTS.md, build a knowledge map, add execution-plan workflows, encode architecture guardrails, expose CI/lint/test feedback to agents, and reduce drift from agent-generated PRs. The cultivate skill is the bridge between a s33ded idea and a repo ready for farmers to execute on. Replaces cultivate.
 ---
 
 # Cultivate Repo

--- a/skills/cultivate/SKILL.md
+++ b/skills/cultivate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cultivate
-description: Cultivate a repository -- prepare it so farmers (AI agents) can work it. Use this skill to make a repo agent-legible and enforceable: create or improve AGENTS.md, build a knowledge map, add execution-plan workflows, encode architecture guardrails, expose CI/lint/test feedback to agents, and reduce drift from agent-generated PRs. The cultivate skill is the bridge between a s33ded idea and a repo ready for farmers to execute on. Replaces cultivate.
+description: Cultivate a repository -- prepare it so farmers (AI agents) can work it. Use this skill to make a repo agent-legible and enforceable: create or improve AGENTS.md, build a knowledge map, add execution-plan workflows, encode architecture guardrails, expose CI/lint/test feedback to agents, and reduce drift from agent-generated PRs. The cultivate skill is the bridge between a seeded idea and a repo ready for farmers to execute on. Replaces cultivate.
 ---
 
 # Cultivate Repo

--- a/skills/plot/SKILL.md
+++ b/skills/plot/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: plot
-description: Plot a project -- capture the minimum viable idea so it can be grown into a real repo. Use this skill whenever the user wants to kick off a new project, describe an idea, flesh out a concept, or produce a structured brief that downstream skills (s33d, cultivate) can act on. Trigger on phrases like "I want to build", "new project idea", "let's start a project", "make a plan for", "I have an idea", or any time the user is at the ideation stage before a repo exists. Plot reads whatever context already exists in the conversation -- don't re-ask things already established -- then asks targeted questions to fill the gaps. Output is a plot.md file: a structured, agent-legible brief.
+description: Plot a project -- capture the minimum viable idea so it can be grown into a real repo. Use this skill whenever the user wants to kick off a new project, describe an idea, flesh out a concept, or produce a structured brief that downstream skills (seed, cultivate) can act on. Trigger on phrases like "I want to build", "new project idea", "let's start a project", "make a plan for", "I have an idea", or any time the user is at the ideation stage before a repo exists. Plot reads whatever context already exists in the conversation -- don't re-ask things already established -- then asks targeted questions to fill the gaps. Output is a plot.md file: a structured, agent-legible brief.
 ---
 
 # Plot
 
 Plot is the first step in the agricultural workflow:
 
-**plot → s33d → cultivate → farmers**
+**plot → seed → cultivate → farmers**
 
 Its job is to capture the minimum viable idea -- enough signal that a repo can be created, seeded, and cultivated for AI agent execution. Think of it as turning a raw idea into a brief that removes ambiguity for every downstream step.
 
@@ -58,7 +58,7 @@ A good plot.md is:
 
 ### Step 5 -- Summarize And Hand Off
 
-After producing the file, give the user a brief summary of what was captured and call out any fields marked TBD that might need resolution before the s33d step. Suggest next steps (run s33d to create the repo, or run cultivate if a repo already exists).
+After producing the file, give the user a brief summary of what was captured and call out any fields marked TBD that might need resolution before the seed step. Suggest next steps (run seed to create the repo, or run cultivate if a repo already exists).
 
 ## Optional Enrichment Phases
 

--- a/skills/plot/SKILL.md
+++ b/skills/plot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plot
-description: Plot a project — capture the minimum viable idea so it can be grown into a real repo. Use this skill whenever the user wants to kick off a new project, describe an idea, flesh out a concept, or produce a structured brief that downstream skills (s33d, cultivate) can act on. Trigger on phrases like "I want to build", "new project idea", "let's start a project", "make a plan for", "I have an idea", or any time the user is at the ideation stage before a repo exists. Plot reads whatever context already exists in the conversation — don't re-ask things already established — then asks targeted questions to fill the gaps. Output is a plot.md file: a structured, agent-legible brief.
+description: Plot a project -- capture the minimum viable idea so it can be grown into a real repo. Use this skill whenever the user wants to kick off a new project, describe an idea, flesh out a concept, or produce a structured brief that downstream skills (s33d, cultivate) can act on. Trigger on phrases like "I want to build", "new project idea", "let's start a project", "make a plan for", "I have an idea", or any time the user is at the ideation stage before a repo exists. Plot reads whatever context already exists in the conversation -- don't re-ask things already established -- then asks targeted questions to fill the gaps. Output is a plot.md file: a structured, agent-legible brief.
 ---
 
 # Plot
@@ -9,54 +9,54 @@ Plot is the first step in the agricultural workflow:
 
 **plot → s33d → cultivate → farmers**
 
-Its job is to capture the minimum viable idea — enough signal that a repo can be created, seeded, and cultivated for AI agent execution. Think of it as turning a raw idea into a brief that removes ambiguity for every downstream step.
+Its job is to capture the minimum viable idea -- enough signal that a repo can be created, seeded, and cultivated for AI agent execution. Think of it as turning a raw idea into a brief that removes ambiguity for every downstream step.
 
 ## How To Run A Plot
 
-### Step 1 — Read The Thread First
+### Step 1 -- Read The Thread First
 
 Before asking anything, scan the current conversation for already-established context. Extract anything that answers the fields in the plot schema (see `references/plot-schema.md`). The user may have already explained the project at length. Don't waste their time repeating questions.
 
 Build a mental draft of the plot.md from what's already known.
 
-### Step 2 — Identify The Gaps
+### Step 2 -- Identify The Gaps
 
 Compare what you extracted against the required fields. Only ask about what's genuinely missing or ambiguous. A good plot session should feel like a focused conversation, not a form.
 
 Required fields (must be present in final output):
-- `name` — kebab-case project identifier
-- `tagline` — one sentence: what it does and for whom
-- `problem` — the core problem or friction being removed
-- `stack` — primary language(s), frameworks, runtime — even rough preferences count
+- `name` -- kebab-case project identifier
+- `tagline` -- one sentence: what it does and for whom
+- `problem` -- the core problem or friction being removed
+- `stack` -- primary language(s), frameworks, runtime -- even rough preferences count
 
 Strongly recommended (ask if not obvious from context):
-- `audience` — who uses this? (can be "just me" �� that's fine)
-- `agents` — what will AI agents actually *do* in this repo? (write code? run evals? manage releases?) This shapes what cultivate will encode.
-- `scope` — MVP boundary: what's in, what's explicitly out
-- `success` — how does a working v1 look? what can you run or observe?
+- `audience` -- who uses this? (can be "just me"  that's fine)
+- `agents` -- what will AI agents actually *do* in this repo? (write code? run evals? manage releases?) This shapes what cultivate will encode.
+- `scope` -- MVP boundary: what's in, what's explicitly out
+- `success` -- how does a working v1 look? what can you run or observe?
 
 Optional enrichment (include if the user volunteers it, don't fish for it):
-- `constraints` — timeline, team size, hard dependencies, existing systems
-- `prospect` — Market or competitive context
-- `survey` — Prior technical research or existing code references
+- `constraints` -- timeline, team size, hard dependencies, existing systems
+- `prospect` -- Market or competitive context
+- `survey` -- Prior technical research or existing code references
 
-### Step 3 — Ask Questions In One Pass
+### Step 3 -- Ask Questions In One Pass
 
-Ask all your gap-filling questions at once rather than one at a time. Group related questions naturally. Keep it conversational — this is a planning chat, not an intake form.
+Ask all your gap-filling questions at once rather than one at a time. Group related questions naturally. Keep it conversational -- this is a planning chat, not an intake form.
 
 If the idea is very rough, lead with open questions. If the idea is well-formed but missing a few specifics, go narrow and targeted.
 
-### Step 4 — Produce plot.md
+### Step 4 -- Produce plot.md
 
 Once you have enough to fill the required fields, write `plot.md` to the working directory. Follow the schema in `references/plot-schema.md`. The file should be readable by both humans and agents.
 
 A good plot.md is:
 - Specific enough that a developer (human or agent) can start making real decisions
 - Honest about what's unknown or TBD
-- Free of marketing fluff — just clear signal
+- Free of marketing fluff -- just clear signal
 - Written in a way that cultivate can use directly to draft AGENTS.md
 
-### Step 5 — Summarize And Hand Off
+### Step 5 -- Summarize And Hand Off
 
 After producing the file, give the user a brief summary of what was captured and call out any fields marked TBD that might need resolution before the s33d step. Suggest next steps (run s33d to create the repo, or run cultivate if a repo already exists).
 
@@ -64,15 +64,15 @@ After producing the file, give the user a brief summary of what was captured and
 
 If the user explicitly asks for research before plotting, or if the idea clearly needs it, two enrichment phases can precede the final plot:
 
-**prospect** — Market and competitive landscape. Who else is doing this? What do users of similar tools complain about? What would make this 10x better?
+**prospect** -- Market and competitive landscape. Who else is doing this? What do users of similar tools complain about? What would make this 10x better?
 
-**survey** — Technical landscape. What libraries, frameworks, or existing repos are relevant? What prior art exists in the user's own codebase?
+**survey** -- Technical landscape. What libraries, frameworks, or existing repos are relevant? What prior art exists in the user's own codebase?
 
 Both are optional. Plot is valid without them. If the user mentions either, do that research before writing plot.md and fold the findings into the relevant sections.
 
 ## Cultivate Alignment
 
-The `agents` field is the most important one for cultivate downstream. Cultivate's job is to make the repo legible and enforceable for AI agents — but what that means depends entirely on what those agents will do.
+The `agents` field is the most important one for cultivate downstream. Cultivate's job is to make the repo legible and enforceable for AI agents -- but what that means depends entirely on what those agents will do.
 
 Examples:
 - "agents will write features and open PRs" → cultivate needs AGENTS.md, PR templates, and CI feedback loops
@@ -83,4 +83,4 @@ If the user hasn't thought about this, prompt them: "*What do you imagine AI age
 
 ## References
 
-Read `references/plot-schema.md` when writing plot.md — it has the exact field definitions and a template.
+Read `references/plot-schema.md` when writing plot.md -- it has the exact field definitions and a template.

--- a/skills/plot/evals/evals.json
+++ b/skills/plot/evals/evals.json
@@ -10,7 +10,7 @@
     {
       "id": 2,
       "prompt": "New project: an MCP server that wraps the Linear API. Target users are developers who use Claude Code and want to manage their Linear issues without leaving the terminal. TypeScript, using the MCP SDK. I want agents to write features and open PRs. MVP is just issues CRUD — create, read, update, close.",
-      "expected_output": "Extract most fields from context with minimal questions. Produce a thorough plot.md with agents field well-populated. Note it's ready for s33d.",
+      "expected_output": "Extract most fields from context with minimal questions. Produce a thorough plot.md with agents field well-populated. Note it's ready for seed.",
       "files": []
     },
     {

--- a/skills/plot/references/plot-schema.md
+++ b/skills/plot/references/plot-schema.md
@@ -47,7 +47,7 @@ status: draft
 
 ## Open Questions
 
-<Unresolved decisions that should be answered before or during s33d. Use TBD if genuinely unknown.>
+<Unresolved decisions that should be answered before or during seed. Use TBD if genuinely unknown.>
 
 ## Prospect (optional)
 

--- a/skills/plot/references/plot-schema.md
+++ b/skills/plot/references/plot-schema.md
@@ -18,7 +18,7 @@ status: draft
 
 ## Audience
 
-<Who uses this? Be specific — "developers building MCP servers" is better than "developers".>
+<Who uses this? Be specific -- "developers building MCP servers" is better than "developers".>
 
 ## Scope (MVP)
 


### PR DESCRIPTION
## Summary

- Adds the `plot` skill — ideation/planning phase of the agricultural workflow (plot → s33d → cultivate → farmers). Reads thread context, asks clarifying questions in one pass, produces a structured `plot.md` with YAML frontmatter and a critical `agents` field for downstream cultivate use. Closes #1.
- Adds GitHub Actions CI that runs skill evals on PRs touching `skills/`. Matrix strategy runs each changed skill independently and posts a pass/fail table as a PR comment. Closes #2.

## Files

- `skills/plot/SKILL.md` — skill instructions
- `skills/plot/references/plot-schema.md` — plot.md field reference
- `skills/plot/evals/evals.json` — 3 evals (env manager CLI, Linear MCP, Zapier-for-Mac idea)
- `.github/workflows/skill-evals.yml` — CI workflow
- `scripts/run_skill_evals.py` — eval runner (calls claude -p, keyword grading)
- `scripts/format_eval_summary.py` — formats results for GitHub step summary

## Setup Required

Add `ANTHROPIC_API_KEY` to repo Settings → Secrets and variables → Actions before CI will run.

## Test plan

- [ ] Review plot skill instructions and schema
- [ ] Check eval prompts cover the key output assertions
- [ ] Verify CI workflow triggers on PR with skill changes
- [ ] Add ANTHROPIC_API_KEY secret to repo settings

🤖 Generated with Claude (Cowork)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add CI workflow to run and report skill evals on pull requests
> - Adds a GitHub Actions workflow ([skill-evals.yml](.github/workflows/skill-evals.yml)) that triggers on PRs touching `skills/**`, detects changed skills with an `evals/evals.json`, runs their evals, and posts a pass/fail table as a PR comment.
> - Adds [scripts/run_skill_evals.py](https://github.com/s33dunda/skills/pull/3/files#diff-437b0dbb702ffe40b86b57f4a5582b0833820e8bae1074ac0964470c0ef10953), which invokes the Claude CLI per eval, grades output via keyword heuristics, writes a structured JSON results file, and exits nonzero when pass rate is below the threshold (default 0.6).
> - Adds [scripts/format_eval_summary.py](https://github.com/s33dunda/skills/pull/3/files#diff-8a1da39f9b102b6a22e3f84419e64b1d3442ec8696c44288df01aa4b5fa2cc19) to render eval results as a markdown summary for GitHub Actions step summaries.
> - Updates `skills/plot/SKILL.md` with changes to the plot skill definition (content redacted in diff).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 083b611.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->